### PR TITLE
Add Contributors Section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,18 @@ We welcome contributions from the community! Whether you're a developer, designe
 
 Please read our [Contributing Guidelines](./CONTRIBUTING.md) and [Code of Conduct](./CODE_OF_CONDUCT.md) before getting started.
 
+---
+
+## ✨ Contributors
+
+#### Thanks to all the wonderful contributors 💖
+
+<a href="https://github.com/xkaper001/DocPilot/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=xkaper001/DocPilot" />
+</a>
+
+---
+
 ## 📜 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -161,13 +161,12 @@ Please read our [Contributing Guidelines](./CONTRIBUTING.md) and [Code of Conduc
 
 ## ✨ Contributors
 
-#### Thanks to all the wonderful contributors 💖
+Thanks to all the wonderful contributors 💖
 
-<a href="https://github.com/xkaper001/DocPilot/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=xkaper001/DocPilot" />
-</a>
+[![Contributors](https://contrib.rocks/image?repo=xkaper001/DocPilot)](https://github.com/xkaper001/DocPilot/graphs/contributors)
 
 ---
+
 
 ## 📜 License
 


### PR DESCRIPTION
Description
This PR adds a Contributors section to the README.md to recognize and showcase all contributors, making the repository more welcoming for new contributors.

Current Problem
The README.md currently lacks a Contributors section to recognize contributors and guide new ones.

Proposed Solution
Add a Contributors section at the end of README.md
Include an auto-generated contributor badge via [contrib.rocks](https://contrib.rocks/)
Update Table of Contents to include this new section
Keep all existing content intact and improve formatting where necessary

Benefits
Recognizes contributors and shows appreciation
Makes the repository more welcoming for new contributors
Improves documentation readability and structure

Close issue #13 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added a Contributors section to the README, including a visual contributors image/graph with a titled header and horizontal separators.
  - Placed the Contributors section in two locations within the README for increased visibility.
  - Documentation-only update; no changes to application behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->